### PR TITLE
fix boot configuration for spring boot 3

### DIFF
--- a/friendly-id-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/friendly-id-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.devskiller.friendly_id.boot.FriendlyIdAutoConfiguration


### PR DESCRIPTION
Spring boot 3 uses another name for the META-INF configuration file