### PR TITLE
Performance fix - compile pattern only once and reuse

### DIFF
--- a/friendly-id/src/main/java/com/devskiller/friendly_id/Base62.java
+++ b/friendly-id/src/main/java/com/devskiller/friendly_id/Base62.java
@@ -18,6 +18,7 @@ class Base62 {
 
 	private static final BigInteger BASE = BigInteger.valueOf(62);
 	private static final String DIGITS = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+	private static final Pattern DIGITS_PATTERN = Pattern.compile("[" + DIGITS + "]*");
 
 	/**
 	 * Encodes a number using Base62 encoding.
@@ -63,7 +64,7 @@ class Base62 {
 			return throwIllegalArgumentException("String '%s' must not be empty", string);
 		}
 
-		if (!Pattern.matches("[" + DIGITS + "]*", string)) {
+		if (!DIGITS_PATTERN.matcher(string).matches()) {
 			throwIllegalArgumentException("String '%s' contains illegal characters, only '%s' are allowed", string, DIGITS);
 		}
 


### PR DESCRIPTION
From java doc java.util.regex.Pattern.matches
"If a pattern is to be used multiple times, compiling it once and reusing it will be more efficient than invoking this method each time."