### PR TITLE
Rename FriendlyIdFormat.RAW to UUID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Spring Boot JPA demo application showcasing FriendlyId with JPA, REST API, and OpenFeign
 
 ### Changed
+- **Breaking**: Renamed `FriendlyIdFormat.RAW` to `FriendlyIdFormat.UUID` for clarity
 - Upgraded from Java 8 to Java 21
 - Upgraded from Spring Boot 2.2.2 to 3.4.1
 - Upgraded from JUnit 4 to JUnit 5

--- a/friendly-id-jackson-datatype/src/main/java/com/devskiller/friendly_id/jackson/FriendlyIdDeserializer.java
+++ b/friendly-id-jackson-datatype/src/main/java/com/devskiller/friendly_id/jackson/FriendlyIdDeserializer.java
@@ -45,7 +45,7 @@ public class FriendlyIdDeserializer extends StdDeserializer<UUID> {
 	public ValueDeserializer<?> createContextual(DeserializationContext ctxt, BeanProperty property) {
 		if (property != null) {
 			var annotation = property.getAnnotation(IdFormat.class);
-			if (annotation != null && annotation.value() == FriendlyIdFormat.RAW) {
+			if (annotation != null && annotation.value() == FriendlyIdFormat.UUID) {
 				return new FriendlyIdDeserializer(false);
 			}
 		}

--- a/friendly-id-jackson-datatype/src/main/java/com/devskiller/friendly_id/jackson/FriendlyIdModule.java
+++ b/friendly-id-jackson-datatype/src/main/java/com/devskiller/friendly_id/jackson/FriendlyIdModule.java
@@ -14,7 +14,7 @@ import com.devskiller.friendly_id.type.FriendlyId;
  * enabling automatic conversion between UUID values and their FriendlyId string representation.
  * </p>
  * <p>
- * By default, UUIDs are serialized as Base62 FriendlyIds. Use {@link FriendlyIdFormat#RAW}
+ * By default, UUIDs are serialized as Base62 FriendlyIds. Use {@link FriendlyIdFormat#UUID}
  * to serialize UUIDs in standard format while still accepting both formats on deserialization.
  * Per-field format can always be overridden with {@link com.devskiller.friendly_id.IdFormat @IdFormat}.
  * </p>
@@ -31,7 +31,7 @@ public class FriendlyIdModule extends SimpleModule {
 	/**
 	 * Creates a module with the specified default serialization format.
 	 * <p>
-	 * When {@link FriendlyIdFormat#RAW} is used, UUIDs are serialized in standard format
+	 * When {@link FriendlyIdFormat#UUID} is used, UUIDs are serialized in standard format
 	 * but deserialization still accepts both standard UUIDs and Base62 FriendlyIds.
 	 * Per-field format can be overridden with {@link com.devskiller.friendly_id.IdFormat @IdFormat}.
 	 *

--- a/friendly-id-jackson-datatype/src/main/java/com/devskiller/friendly_id/jackson/FriendlyIdSerializer.java
+++ b/friendly-id-jackson-datatype/src/main/java/com/devskiller/friendly_id/jackson/FriendlyIdSerializer.java
@@ -38,7 +38,7 @@ public class FriendlyIdSerializer extends StdSerializer<UUID> {
 	public ValueSerializer<?> createContextual(SerializationContext ctxt, BeanProperty property) {
 		if (property != null) {
 			IdFormat annotation = property.getAnnotation(IdFormat.class);
-			if (annotation != null && annotation.value() == FriendlyIdFormat.RAW) {
+			if (annotation != null && annotation.value() == FriendlyIdFormat.UUID) {
 				return new FriendlyIdSerializer(false);
 			}
 		}

--- a/friendly-id-jackson-datatype/src/test/java/com/devskiller/friendly_id/spring/Bar.java
+++ b/friendly-id-jackson-datatype/src/test/java/com/devskiller/friendly_id/spring/Bar.java
@@ -6,6 +6,6 @@ import com.devskiller.friendly_id.FriendlyIdFormat;
 import com.devskiller.friendly_id.IdFormat;
 
 public record Bar(
-		@IdFormat(FriendlyIdFormat.RAW) UUID rawUuid,
+		@IdFormat(FriendlyIdFormat.UUID) UUID rawUuid,
 		UUID friendlyId
 ) {}

--- a/friendly-id-jackson-datatype/src/test/java/com/devskiller/friendly_id/spring/Foo.java
+++ b/friendly-id-jackson-datatype/src/test/java/com/devskiller/friendly_id/spring/Foo.java
@@ -6,6 +6,6 @@ import com.devskiller.friendly_id.FriendlyIdFormat;
 import com.devskiller.friendly_id.IdFormat;
 
 public record Foo(
-		@IdFormat(FriendlyIdFormat.RAW) UUID rawUuid,
+		@IdFormat(FriendlyIdFormat.UUID) UUID rawUuid,
 		UUID friendlyId
 ) {}

--- a/friendly-id-jackson-datatype/src/test/java/com/devskiller/friendly_id/spring/RawFormatModuleTest.java
+++ b/friendly-id-jackson-datatype/src/test/java/com/devskiller/friendly_id/spring/RawFormatModuleTest.java
@@ -16,7 +16,7 @@ class RawFormatModuleTest {
 	private final UUID uuid = UUID.fromString("f088ce5b-9279-4cc3-946a-c15ad740dd6d");
 
 	private final JsonMapper mapper = JsonMapper.builder()
-			.addModule(new FriendlyIdModule(FriendlyIdFormat.RAW))
+			.addModule(new FriendlyIdModule(FriendlyIdFormat.UUID))
 			.build();
 
 	@Test
@@ -48,9 +48,9 @@ class RawFormatModuleTest {
 
 		String json = mapper.writeValueAsString(foo);
 
-		// rawUuid has @IdFormat(RAW) -> standard format
+		// rawUuid has @IdFormat(UUID) -> standard format
 		assertThat(json).contains("\"rawUuid\":\"f088ce5b-9279-4cc3-946a-c15ad740dd6d\"");
-		// friendlyId has no annotation, module default is RAW -> standard format
+		// friendlyId has no annotation, module default is UUID -> standard format
 		assertThat(json).contains("\"friendlyId\":\"f088ce5b-9279-4cc3-946a-c15ad740dd6d\"");
 	}
 

--- a/friendly-id-jackson2-datatype/src/main/java/com/devskiller/friendly_id/jackson2/FriendlyIdAnnotationIntrospector.java
+++ b/friendly-id-jackson2-datatype/src/main/java/com/devskiller/friendly_id/jackson2/FriendlyIdAnnotationIntrospector.java
@@ -21,7 +21,7 @@ public class FriendlyIdAnnotationIntrospector extends JacksonAnnotationIntrospec
 		IdFormat annotation = _findAnnotation(annotatedMethod, IdFormat.class);
 		if (annotatedMethod.getRawType() == UUID.class && annotation != null) {
 			return switch (annotation.value()) {
-				case RAW -> UUIDSerializer.class;
+				case UUID -> UUIDSerializer.class;
 				case URL62 -> FriendlyIdSerializer.class;
 			};
 		}
@@ -33,7 +33,7 @@ public class FriendlyIdAnnotationIntrospector extends JacksonAnnotationIntrospec
 		var annotation = _findAnnotation(annotatedMethod, IdFormat.class);
 		if (rawDeserializationType(annotatedMethod) == UUID.class && annotation != null) {
 			return switch (annotation.value()) {
-				case RAW -> UUIDDeserializer.class;
+				case UUID -> UUIDDeserializer.class;
 				case URL62 -> FriendlyIdDeserializer.class;
 			};
 		}

--- a/friendly-id-jackson2-datatype/src/test/java/com/devskiller/friendly_id/spring/Bar.java
+++ b/friendly-id-jackson2-datatype/src/test/java/com/devskiller/friendly_id/spring/Bar.java
@@ -7,7 +7,7 @@ import com.devskiller.friendly_id.IdFormat;
 
 public class Bar {
 
-	@IdFormat(FriendlyIdFormat.RAW)
+	@IdFormat(FriendlyIdFormat.UUID)
 	private final UUID rawUuid;
 
 	private final UUID friendlyId;

--- a/friendly-id-jackson2-datatype/src/test/java/com/devskiller/friendly_id/spring/Foo.java
+++ b/friendly-id-jackson2-datatype/src/test/java/com/devskiller/friendly_id/spring/Foo.java
@@ -7,7 +7,7 @@ import com.devskiller.friendly_id.IdFormat;
 
 public class Foo {
 
-	@IdFormat(FriendlyIdFormat.RAW)
+	@IdFormat(FriendlyIdFormat.UUID)
 	private UUID rawUuid;
 
 	private UUID friendlyId;

--- a/friendly-id-jackson2-datatype/src/test/java/com/devskiller/friendly_id/spring/RawFormatModuleTest.java
+++ b/friendly-id-jackson2-datatype/src/test/java/com/devskiller/friendly_id/spring/RawFormatModuleTest.java
@@ -16,7 +16,7 @@ class RawFormatModuleTest {
 	private final UUID uuid = UUID.fromString("f088ce5b-9279-4cc3-946a-c15ad740dd6d");
 
 	private final ObjectMapper mapper = new ObjectMapper()
-			.registerModule(new FriendlyIdJackson2Module(FriendlyIdFormat.RAW));
+			.registerModule(new FriendlyIdJackson2Module(FriendlyIdFormat.UUID));
 
 	@Test
 	void shouldSerializeUuidInStandardFormat() throws Exception {
@@ -49,9 +49,9 @@ class RawFormatModuleTest {
 
 		String json = mapper.writeValueAsString(foo);
 
-		// rawUuid has @IdFormat(RAW) -> standard format
+		// rawUuid has @IdFormat(UUID) -> standard format
 		assertThat(json).contains("\"rawUuid\":\"f088ce5b-9279-4cc3-946a-c15ad740dd6d\"");
-		// friendlyId has no annotation, module default is RAW -> standard format
+		// friendlyId has no annotation, module default is UUID -> standard format
 		assertThat(json).contains("\"friendlyId\":\"f088ce5b-9279-4cc3-946a-c15ad740dd6d\"");
 	}
 }

--- a/friendly-id-samples/friendly-id-contracts/src/main/java/com/devskiller/friendly_id/sample/contracts/Item.java
+++ b/friendly-id-samples/friendly-id-contracts/src/main/java/com/devskiller/friendly_id/sample/contracts/Item.java
@@ -10,13 +10,13 @@ import com.devskiller.friendly_id.type.FriendlyId;
  * Example record demonstrating different UUID serialization formats.
  *
  * @param id           UUID serialized as FriendlyId string (default behavior)
- * @param rawId        UUID serialized as raw UUID string
+ * @param rawId        UUID serialized in standard UUID format
  * @param friendlyUuid UUID explicitly serialized as FriendlyId string
  * @param friendlyId   FriendlyId value object type
  */
 public record Item(
 		UUID id,
-		@IdFormat(FriendlyIdFormat.RAW) UUID rawId,
+		@IdFormat(FriendlyIdFormat.UUID) UUID rawId,
 		@IdFormat(FriendlyIdFormat.URL62) UUID friendlyUuid,
 		FriendlyId friendlyId
 ) {

--- a/friendly-id-samples/friendly-id-spring-boot-customized/src/main/java/com/devskiller/friendly_id/sample/customized/Item.java
+++ b/friendly-id-samples/friendly-id-spring-boot-customized/src/main/java/com/devskiller/friendly_id/sample/customized/Item.java
@@ -10,13 +10,13 @@ import com.devskiller.friendly_id.type.FriendlyId;
  * Example record demonstrating different UUID serialization formats.
  *
  * @param id           UUID serialized as FriendlyId string (default behavior)
- * @param rawId        UUID serialized as raw UUID string
+ * @param rawId        UUID serialized in standard UUID format
  * @param friendlyUuid UUID explicitly serialized as FriendlyId string
  * @param friendlyId   FriendlyId value object type
  */
 public record Item(
 		UUID id,
-		@IdFormat(FriendlyIdFormat.RAW) UUID rawId,
+		@IdFormat(FriendlyIdFormat.UUID) UUID rawId,
 		@IdFormat(FriendlyIdFormat.URL62) UUID friendlyUuid,
 		FriendlyId friendlyId
 ) {

--- a/friendly-id-samples/friendly-id-spring-boot-simple/src/main/java/com/devskiller/friendly_id/sample/simple/Item.java
+++ b/friendly-id-samples/friendly-id-spring-boot-simple/src/main/java/com/devskiller/friendly_id/sample/simple/Item.java
@@ -10,13 +10,13 @@ import com.devskiller.friendly_id.type.FriendlyId;
  * Example record demonstrating different UUID serialization formats.
  *
  * @param id           UUID serialized as FriendlyId string (default behavior)
- * @param rawId        UUID serialized as raw UUID string
+ * @param rawId        UUID serialized in standard UUID format
  * @param friendlyUuid UUID explicitly serialized as FriendlyId string
  * @param friendlyId   FriendlyId value object type
  */
 public record Item(
 		UUID id,
-		@IdFormat(FriendlyIdFormat.RAW) UUID rawId,
+		@IdFormat(FriendlyIdFormat.UUID) UUID rawId,
 		@IdFormat(FriendlyIdFormat.URL62) UUID friendlyUuid,
 		FriendlyId friendlyId
 ) {

--- a/friendly-id-samples/friendly-id-spring-boot3-simple/src/main/java/com/devskiller/friendly_id/sample/spring3/Item.java
+++ b/friendly-id-samples/friendly-id-spring-boot3-simple/src/main/java/com/devskiller/friendly_id/sample/spring3/Item.java
@@ -10,13 +10,13 @@ import com.devskiller.friendly_id.type.FriendlyId;
  * Example record demonstrating different UUID serialization formats.
  *
  * @param id           UUID serialized as FriendlyId string (default behavior)
- * @param rawId        UUID serialized as raw UUID string
+ * @param rawId        UUID serialized in standard UUID format
  * @param friendlyUuid UUID explicitly serialized as FriendlyId string
  * @param friendlyId   FriendlyId value object type
  */
 public record Item(
 		UUID id,
-		@IdFormat(FriendlyIdFormat.RAW) UUID rawId,
+		@IdFormat(FriendlyIdFormat.UUID) UUID rawId,
 		@IdFormat(FriendlyIdFormat.URL62) UUID friendlyUuid,
 		FriendlyId friendlyId
 ) {

--- a/friendly-id/src/main/java/com/devskiller/friendly_id/FriendlyIdFormat.java
+++ b/friendly-id/src/main/java/com/devskiller/friendly_id/FriendlyIdFormat.java
@@ -11,7 +11,7 @@ public enum FriendlyIdFormat {
 	URL62,
 
 	/**
-	 * Leave this ID as is (without conversion)
+	 * Standard UUID format (without Base62 conversion)
 	 */
-	RAW
+	UUID
 }


### PR DESCRIPTION
## Summary
- Rename `FriendlyIdFormat.RAW` to `FriendlyIdFormat.UUID` for better readability
- `@IdFormat(FriendlyIdFormat.UUID)` clearly communicates the intent vs ambiguous `RAW`
- Updated all references across core, Jackson 2/3 modules, samples, and CHANGELOG

## Test plan
- [x] All module tests pass (`mvn test` excluding samples with pre-existing Lombok issue)